### PR TITLE
[修改]ControllerBaseX中OnActionExecuting时不再处理PageSetting.EnableSelect

### DIFF
--- a/NewLife.Cube/Common/ControllerBaseX.cs
+++ b/NewLife.Cube/Common/ControllerBaseX.cs
@@ -49,10 +49,10 @@ public class ControllerBaseX : Controller
             HttpContext.Items["userId"] = user.ID;
 
             // 没有菜单时不做权限控制
-            if (Menu != null)
-            {
-                PageSetting.EnableSelect = user.Has(Menu, PermissionFlags.Update, PermissionFlags.Delete);
-            }
+            //if (Menu != null)
+            //{
+            //    PageSetting.EnableSelect = user.Has(Menu, PermissionFlags.Update, PermissionFlags.Delete);
+            //}
         }
 
         base.OnActionExecuting(context);


### PR DESCRIPTION
 // 没有菜单时不做权限控制
            if (Menu != null)
            {
                PageSetting.EnableSelect = user.Has(Menu, PermissionFlags.Update, PermissionFlags.Delete);
            }
改为:
 // 没有菜单时不做权限控制
            //if (Menu != null)
            //{
            //    PageSetting.EnableSelect = user.Has(Menu, PermissionFlags.Update, PermissionFlags.Delete);
            //}