### PR TITLE
修改OAuth的部门和用户模型中部门ID、部门ParentID数据类型为String

### DIFF
--- a/NewLife.Cube/Web/Models/DepartmentInfo.cs
+++ b/NewLife.Cube/Web/Models/DepartmentInfo.cs
@@ -6,7 +6,7 @@ namespace NewLife.Cube.Web.Models
     public class DepartmentInfo
     {
         /// <summary>编号</summary>
-        public Int32 Id { get; set; }
+        public String Id { get; set; }
 
         /// <summary>名称</summary>
         public String Name { get; set; }
@@ -15,7 +15,7 @@ namespace NewLife.Cube.Web.Models
         public String EnglishName { get; set; }
 
         /// <summary>父级部门。根部门1</summary>
-        public Int32 ParentId { get; set; }
+        public String ParentId { get; set; }
 
         /// <summary>顺序</summary>
         public Int32 Order { get; set; }

--- a/NewLife.Cube/Web/Models/UserInfo.cs
+++ b/NewLife.Cube/Web/Models/UserInfo.cs
@@ -17,7 +17,7 @@ namespace NewLife.Cube.Web.Models
         public String Mobile { get; set; }
 
         /// <summary>部门</summary>
-        public Int32[] Department { get; set; }
+        public String[] Department { get; set; }
 
         /// <summary>顺序</summary>
         public Int32[] Order { get; set; }

--- a/NewLife.Cube/Web/OAuth/QyWeiXin.cs
+++ b/NewLife.Cube/Web/OAuth/QyWeiXin.cs
@@ -132,7 +132,7 @@ public class QyWeiXin : OAuthClient
     /// <param name="departmentId"></param>
     /// <param name="fetchChild"></param>
     /// <returns></returns>
-    public async Task<UserInfo[]> GetUsers(Int32 departmentId, Boolean fetchChild = false)
+    public async Task<UserInfo[]> GetUsers(String departmentId, Boolean fetchChild = false)
     {
         var token = await GetAccessToken();
 
@@ -332,9 +332,8 @@ public class QyWeiXin : OAuthClient
             }
 
             // 根据部门编码，填充部门名称
-            var code = DepartmentCode.ToInt();
             //if (!DepartmentCode.IsNullOrEmpty() && DepartmentName.IsNullOrEmpty())
-            if (code > 0 && DepartmentName.IsNullOrEmpty())
+            if (DepartmentCode.ToLong() > 0 && DepartmentName.IsNullOrEmpty())
             {
                 var key = $"sso:dps:{CorpId}";
                 var dps = _cache.Get<DepartmentInfo[]>(key);
@@ -345,7 +344,7 @@ public class QyWeiXin : OAuthClient
                     _cache.Set(key, dps, 3600);
                 }
 
-                var dp = dps?.FirstOrDefault(e => e.Id == code);
+                var dp = dps?.FirstOrDefault(e => e.Id == DepartmentCode);
                 if (dp != null) DepartmentName = dp.Name;
             }
         }

--- a/XUnitTest/QyWeiXinTests.cs
+++ b/XUnitTest/QyWeiXinTests.cs
@@ -93,7 +93,7 @@ public class QyWeiXinTests
             CorpSecret = ss[1]
         };
 
-        var users = await wx.GetUsers(17, true);
+        var users = await wx.GetUsers("17", true);
 
         Assert.NotNull(users);
         Assert.Contains(users, e => e.Alias == "大石头");


### PR DESCRIPTION
企业微信的部门ID数据类型为整型(取值范围为0~2^32)，所以把魔方中OAuth的部门和用户模型的部门ID和ParentID数据类型从Int32修改为String